### PR TITLE
Minor fix to assets

### DIFF
--- a/client/components/overview/AssetsGuide.js
+++ b/client/components/overview/AssetsGuide.js
@@ -57,7 +57,7 @@ function AssetsGuide() {
         "sSYNR, or Synthetic SYNR, is in-game synthetic currency that will be usable only in-game and in the MOBLAND marketplace. sSYNR can only be acquired by staking SYNR and can be swapped in the SEED Farm to generate SEED instead!",
       where: [
         {
-          link: "#",
+          link: "https://staking.mob.land/core/dashboard",
           src: mobland,
         },
         ,

--- a/client/components/overview/InfoTileItem.js
+++ b/client/components/overview/InfoTileItem.js
@@ -17,7 +17,7 @@ function InfoTileItem({ cls = "", alt, title, img, description, where }) {
             }}
           >
             <div className={"info-tile-title bold mulish"}>
-              {title.toUpperCase()}
+              {title}
             </div>
           </Box>
           <ul style={{ paddingLeft: 0 }}>


### PR DESCRIPTION
Minor fix to Assets. The link for sSYNR was missed, while it should link to the Core Pool