### PR TITLE
Fix generic links at the bottom of the seedfarmguide

### DIFF
--- a/client/components/overview/InfoTileItem.js
+++ b/client/components/overview/InfoTileItem.js
@@ -16,9 +16,7 @@ function InfoTileItem({ cls = "", alt, title, img, description, where }) {
               mb: 2,
             }}
           >
-            <div className={"info-tile-title bold mulish"}>
-              {title}
-            </div>
+            <div className={"info-tile-title bold mulish"}>{title}</div>
           </Box>
           <ul style={{ paddingLeft: 0 }}>
             <Typography

--- a/client/components/overview/NftExchange.js
+++ b/client/components/overview/NftExchange.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { CardMedia, Stack } from "@mui/material";
+import { Link } from "react-router-dom";
 import Title from "../tile/Title";
 
 import mobland from "../../images/mobland-white-icon.png";
@@ -32,30 +33,31 @@ function NftExchange({ title = "", style = {} }) {
   return (
     <div>
       {title ? <Title title={title} upperCase={false} /> : null}
-      <Stack
-        direction="row"
-        spacing={3}
-        align="center"
-        justifyContent="center"
-        sx={style}
-      >
-        {exchanges.map((exchange, index) => {
-          return (
-            <a href={exchange.link} key={"exchange_" + i++}>
-              <CardMedia
-                key={"exchange_" + i++}
-                style={{
-                  width: "auto",
-                  maxHeight: exchange.height,
-                  paddingTop: exchange.padding,
-                }}
-                component="img"
-                image={exchange.img}
-              />
-            </a>
-          );
-        })}
-      </Stack>
+      <div className={'centered'}>Look at <Link to={"/assetsguide"}><span className={"yellow"}>Assets</span> </Link> to see where to get them.</div>
+      {/*<Stack*/}
+      {/*  direction="row"*/}
+      {/*  spacing={3}*/}
+      {/*  align="center"*/}
+      {/*  justifyContent="center"*/}
+      {/*  sx={style}*/}
+      {/*>*/}
+      {/*  {exchanges.map((exchange, index) => {*/}
+      {/*    return (*/}
+      {/*      <a href={exchange.link} key={"exchange_" + i++}>*/}
+      {/*        <CardMedia*/}
+      {/*          key={"exchange_" + i++}*/}
+      {/*          style={{*/}
+      {/*            width: "auto",*/}
+      {/*            maxHeight: exchange.height,*/}
+      {/*            paddingTop: exchange.padding,*/}
+      {/*          }}*/}
+      {/*          component="img"*/}
+      {/*          image={exchange.img}*/}
+      {/*        />*/}
+      {/*      </a>*/}
+      {/*    );*/}
+      {/*  })}*/}
+      {/*</Stack>*/}
     </div>
   );
 }

--- a/client/components/overview/SeedFarmGuide.js
+++ b/client/components/overview/SeedFarmGuide.js
@@ -139,7 +139,7 @@ function SeedFarmGuide() {
           />
         </Grid>
         <Grid item xs={12} sm={6} md={6} className={"distanceFooter"}>
-          <NftExchange title="NFT's are available on these platforms:" />
+          <NftExchange title="No NFT?" />
         </Grid>
       </Grid>
     </div>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -276,7 +276,7 @@ a.yellowHover {
     color: whitesmoke !important;
 }
 
-a.yellowHover:hover {
+.yellow, a.yellowHover:hover {
     color: yellow !important;
 }
 


### PR DESCRIPTION
Remove generic links at the bottom of _seedfarmguide_ replacing them with a link to Assets.