### PR TITLE
Fix white images issue

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -2659,6 +2659,6 @@ b,
 .tile {
     padding-bottom: 18px;
 }
-.css-s18byi{
-background-color: transparent !important;
+.css-s18byi {
+    background-color: transparent !important;
 }

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -2659,3 +2659,6 @@ b,
 .tile {
     padding-bottom: 18px;
 }
+.css-s18byi{
+background-color: transparent !important;
+}

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -2659,6 +2659,6 @@ b,
 .tile {
     padding-bottom: 18px;
 }
-.css-s18byi {
+.MuiCard-root {
     background-color: transparent !important;
 }


### PR DESCRIPTION
<img width="981" alt="Screen Shot 2023-02-10 at 11 31 51 AM" src="https://user-images.githubusercontent.com/22923794/218130878-2f2b8462-b1c1-4bff-bfbb-71fa5dbc2884.png">
Somewhere along the way we must have done some change that made it background white.  This PR is a quick fix for that.