### PR TITLE
Fix loading path from footer

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,12 +11,12 @@ module.exports = merge(common, {
 
   devtool: "inline-source-map",
   output: {
-    path: __dirname + "/bundle-dev",
+    path: __dirname + "/bundle",
     publicPath: "",
     filename: "bundle.min.js",
   },
   devServer: {
-    contentBase: "./bundle-dev",
+    contentBase: "./bundle",
   },
   module: {
     rules: [
@@ -28,9 +28,14 @@ module.exports = merge(common, {
         test: /\.(jpe?g|png|gif|svg|webp|mp4)$/,
         exclude: /node_modules/,
         type: "asset/resource",
-        generator: {
-          outputPath: "images/",
-        },
+        // generator: {
+        //   outputPath: "images/",
+        // },
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: "asset/resource",
+        exclude: /node_modules/,
       },
     ],
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
   devtool: "source-map",
   output: {
     path: path.join(__dirname, "/bundle"),
-    publicPath: "/",
+    publicPath: "",
     filename: "bundle.min.[fullhash].js",
   },
   module: {
@@ -59,12 +59,12 @@ module.exports = merge(common, {
       // filename: "assets/css/[name].[contenthash].css",
     }),
     new CompressionWebpackPlugin({
-      deleteOriginalAssets: true,
+      // deleteOriginalAssets: true,
       test: /\.(js|css|html|webp|ttf|mp4)$/,
       algorithm: "gzip",
     }),
     new CompressionWebpackPlugin({
-      deleteOriginalAssets: true,
+      // deleteOriginalAssets: true,
       test: /\.(js|css|html|webp|ttf|mp4)$/,
       algorithm: "brotliCompress",
     }),


### PR DESCRIPTION
Fix loading error when accessing a path  directly for example mob.land/assetsguide

Done:
1/ Somehow when loading a route directly, the app tries to serve mob.land/index.html.
If the webpack configuration in production is set to remove the original assets after compression, the previous operation fails.
The temporary fix was to keep the original non-compressed version of the assets:
```json
{
    new CompressionWebpackPlugin({
      // deleteOriginalAssets: true,     <==== this!
      test: /\.(js|css|html|webp|ttf|mp4)$/,
      algorithm: "gzip",
    }),
    new CompressionWebpackPlugin({
      // deleteOriginalAssets: true,     <==== this!
      test: /\.(js|css|html|webp|ttf|mp4)$/,
      algorithm: "brotliCompress",
    }),
}
```  
2/ Also fixed the development mode

Todo:
- find a fix that works even when original assets are deletes